### PR TITLE
Fix singletons requirements

### DIFF
--- a/ch13/elevator/Elevator/Safe/Operations.hs
+++ b/ch13/elevator/Elevator/Safe/Operations.hs
@@ -1,23 +1,5 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE EmptyCase #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE StandaloneDeriving #-}
-#if __GLASGOW_HASKELL__ >= 810
-{-# LANGUAGE StandaloneKindSignatures #-}
-#endif
-
+{-# LANGUAGE RankNTypes #-}
 
 module Elevator.Safe.Operations where
 

--- a/du/AppTypes.hs
+++ b/du/AppTypes.hs
@@ -17,7 +17,7 @@ data AppEnv = AppEnv {
   }
 
 initialEnv :: AppConfig -> AppEnv
-initialEnv config @ AppConfig {..} = AppEnv {
+initialEnv config@AppConfig {..} = AppEnv {
     cfg = config
   , path = basePath
   , depth = 0

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -1,10 +1,8 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: cc0594af8853ca44b3768289d1945f8282faca9d7a799eb64e7960b6175122de
 
 name:           hid-examples
 version:        0.5
@@ -17,8 +15,9 @@ author:         Vitaly Bragilevsky
 maintainer:     Vitaly Bragilevsky <vit.bragilevsky@gmail.com>
 license:        BSD3
 license-file:   LICENSE
-tested-with:    GHC == 8.6.5, GHC == 8.8.3
 build-type:     Simple
+tested-with:
+    GHC == 9.2.7
 extra-source-files:
     ChangeLog.md
     LICENSE
@@ -68,7 +67,7 @@ library
       empty
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 library contexts
@@ -78,7 +77,7 @@ library contexts
       ch02
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , mtl >=2.0 && <2.3
   default-language: Haskell2010
 
@@ -89,7 +88,7 @@ library expr-simple
       expr
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , text-show >=3.0 && <4
   default-language: Haskell2010
 
@@ -100,8 +99,8 @@ library ipgen-lib
       ip/gen
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
-    , hedgehog >=0.5 && <1.1
+      base ==4.16.*
+    , hedgehog >=0.5 && <1.2
     , iplookup-lib
   default-language: Haskell2010
 
@@ -113,12 +112,13 @@ library iplookup-lib
       FastLookup
   hs-source-dirs:
       ip/lookup
-  other-extensions: TypeApplications
+  other-extensions:
+      TypeApplications
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-incomplete-uni-patterns
   build-depends:
-      base >=4.12 && <4.15
-    , fingertree >=0.1 && <0.2
-    , split >=0.2 && <0.3
+      base ==4.16.*
+    , fingertree ==0.1.*
+    , split ==0.2.*
   default-language: Haskell2010
 
 library isprime-lib
@@ -129,7 +129,7 @@ library isprime-lib
       ch09/isprime
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 library radar-lib
@@ -139,7 +139,7 @@ library radar-lib
       ch02/radar
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 library rpc-lib
@@ -152,21 +152,23 @@ library rpc-lib
       RemoteIO
       RemoteParser
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch12/rpc/lib
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , bytestring >=0.10 && <0.12
-    , cereal >=0.5 && <0.6
-    , connection >=0.3 && <0.4
-    , exceptions >=0.10 && <0.11
+    , cereal ==0.5.*
+    , connection ==0.3.*
+    , exceptions ==0.10.*
     , haskell-src-exts >=1.20 && <1.24
     , haskell-src-meta >=0.6 && <0.9
     , mtl >=2.0 && <2.3
     , network >=2.8 && <3.2
     , network-simple >=0.4.5 && <0.5
-    , template-haskell >=2.13 && <2.17
+    , template-haskell >=2.13 && <2.19
   default-language: Haskell2010
 
 library shunting-yard
@@ -176,7 +178,7 @@ library shunting-yard
       expr
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , expr-simple
     , mtl >=2.0 && <2.3
     , text-show >=3.0 && <4
@@ -186,13 +188,15 @@ executable api-servant
   main-is: ch13/api/ApiServant.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      aeson >=1.2 && <1.6
-    , base >=4.12 && <4.15
-    , blaze-html >=0.9 && <0.10
+      aeson ==2.0.*
+    , base ==4.16.*
+    , blaze-html ==0.9.*
     , servant-blaze >=0.7 && <0.10
-    , servant-server >=0.14 && <0.19
+    , servant-server >=0.14 && <0.20
     , warp >=3.2 && <3.4
   default-language: Haskell2010
 
@@ -200,67 +204,94 @@ executable api-stage0
   main-is: ch13/api/Api0.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable api-stage1
   main-is: ch13/api/Api1.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable api-stage2
   main-is: ch13/api/Api2.hs
   other-modules:
       Paths_hid_examples
-  other-extensions: KindSignatures TypeOperators PolyKinds DataKinds TypeFamilies
+  autogen-modules:
+      Paths_hid_examples
+  other-extensions:
+      KindSignatures
+      TypeOperators
+      PolyKinds
+      DataKinds
+      TypeFamilies
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable api-stage3
   main-is: ch13/api/Api3.hs
   other-modules:
       Paths_hid_examples
-  other-extensions: KindSignatures TypeOperators PolyKinds DataKinds TypeFamilies FlexibleInstances InstanceSigs ScopedTypeVariables
+  autogen-modules:
+      Paths_hid_examples
+  other-extensions:
+      KindSignatures
+      TypeOperators
+      PolyKinds
+      DataKinds
+      TypeFamilies
+      FlexibleInstances
+      InstanceSigs
+      ScopedTypeVariables
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable async-exc
   main-is: ch16/async-exc.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -threaded
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable basic-deriv
   main-is: basic-deriv.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch12/deriv/
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable chars
   main-is: ch14/chars.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , streaming >=0.2.2 && <0.4
   default-language: Haskell2010
 
@@ -268,31 +299,37 @@ executable coerce
   main-is: coerce.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch12/deriv/
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable conc-hello
   main-is: ch16/conc-hello.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -threaded
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable copy
   main-is: ch14/copy.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , filepath >=1.4.1 && <1.5
-    , resourcet >=1.2 && <1.3
+    , resourcet ==1.2.*
     , streaming >=0.2.2 && <0.4
     , streaming-bytestring >=0.1.7 && <0.3
   default-language: Haskell2010
@@ -301,11 +338,13 @@ executable countzeros
   main-is: countzeros.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch05
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable covid
@@ -314,20 +353,22 @@ executable covid
       CovidCSVParser
       CovidData
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch14/covid
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      attoparsec >=0.13 && <0.14
-    , base >=4.12 && <4.15
+      attoparsec ==0.14.*
+    , base ==4.16.*
     , bytestring >=0.10 && <0.12
     , containers >=0.5 && <0.7
-    , lens >=4.17 && <4.20
-    , resourcet >=1.2 && <1.3
+    , lens ==5.1.*
+    , resourcet ==1.2.*
     , streaming >=0.2.2 && <0.4
     , streaming-bytestring >=0.1.7 && <0.3
-    , streaming-utils >=0.2 && <0.3
-    , text >=1.2 && <1.3
+    , streaming-utils ==0.2.*
+    , text ==1.2.*
     , text-show >=3.0 && <4
     , time >=1.8 && <1.12
   default-language: Haskell2010
@@ -336,112 +377,143 @@ executable csv-simple
   main-is: ch14/csv-simple.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      attoparsec >=0.13 && <0.14
-    , base >=4.12 && <4.15
+      attoparsec ==0.14.*
+    , base ==4.16.*
     , bytestring >=0.10 && <0.12
-    , resourcet >=1.2 && <1.3
+    , resourcet ==1.2.*
     , streaming >=0.2.2 && <0.4
     , streaming-bytestring >=0.1.7 && <0.3
-    , streaming-utils >=0.2 && <0.3
-    , text >=1.2 && <1.3
+    , streaming-utils ==0.2.*
+    , text ==1.2.*
   default-language: Haskell2010
 
 executable dicegame
   main-is: dicegame.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch05
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , mtl >=2.0 && <2.3
-    , random >=1.2 && <1.3
+    , random ==1.2.*
   default-language: Haskell2010
 
 executable div
   main-is: div.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch07
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
-    , exceptions >=0.10 && <0.11
+      base ==4.16.*
+    , exceptions ==0.10.*
   default-language: Haskell2010
 
 executable door
   main-is: ch13/doors/SingManual.hs
   other-modules:
       Paths_hid_examples
-  other-extensions: DataKinds GADTs TypeOperators KindSignatures StandaloneDeriving
+  autogen-modules:
+      Paths_hid_examples
+  other-extensions:
+      DataKinds
+      GADTs
+      TypeOperators
+      KindSignatures
+      StandaloneDeriving
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-unticked-promoted-constructors
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable door-gen
   main-is: ch13/doors/SingGen.hs
   other-modules:
       Paths_hid_examples
-  other-extensions: DataKinds GADTs TypeOperators KindSignatures StandaloneDeriving
+  autogen-modules:
+      Paths_hid_examples
+  other-extensions:
+      DataKinds
+      GADTs
+      TypeOperators
+      KindSignatures
+      StandaloneDeriving
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-unticked-promoted-constructors
   build-depends:
-      base >=4.12 && <4.15
-    , singletons >=2.5 && <2.8
+      base ==4.16.*
+    , singletons >=2.5 && <3.1
+    , singletons-th ==3.1.*
   default-language: Haskell2010
 
 executable dots
   main-is: ch16/dots.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -threaded
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable dots-async
   main-is: ch16/dots-async.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -threaded
   build-depends:
       async >=2.0 && <2.3
-    , base >=4.12 && <4.15
+    , base ==4.16.*
   default-language: Haskell2010
 
 executable dots-async-cancel
   main-is: ch16/dots-async-cancel.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -threaded
   build-depends:
       async >=2.0 && <2.3
-    , base >=4.12 && <4.15
-    , random >=1.2 && <1.3
+    , base ==4.16.*
+    , random ==1.2.*
   default-language: Haskell2010
 
 executable dots-async-interrupted
   main-is: ch16/dots-async-interrupted.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -threaded
   build-depends:
       async >=2.0 && <2.3
-    , base >=4.12 && <4.15
+    , base ==4.16.*
   default-language: Haskell2010
 
 executable dots-stm
   main-is: ch16/dots-stm.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -threaded
   build-depends:
       async >=2.0 && <2.3
-    , base >=4.12 && <4.15
+    , base ==4.16.*
     , stm >=2.4 && <2.6
   default-language: Haskell2010
 
@@ -457,31 +529,40 @@ executable du
       FileCounter
       Utils
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       du
-  default-extensions: RecordWildCards NamedFieldPuns OverloadedStrings
-  other-extensions: GeneralizedNewtypeDeriving
+  default-extensions:
+      RecordWildCards
+      NamedFieldPuns
+      OverloadedStrings
+  other-extensions:
+      GeneralizedNewtypeDeriving
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
-    , directory >=1.3 && <1.4
+      base ==4.16.*
+    , directory ==1.3.*
     , extra >=1.5 && <1.8
     , filepath >=1.4.1 && <1.5
     , mtl >=2.0 && <2.3
-    , optparse-applicative >=0.14 && <0.17
-    , text >=1.2 && <1.3
+    , optparse-applicative ==0.17.*
+    , text ==1.2.*
     , text-show >=3.0 && <4
-    , unix-compat >=0.5 && <0.6
+    , unix-compat ==0.5.*
   default-language: Haskell2010
 
 executable dynvalues-gadt
   main-is: ch11/dynvalues-gadt.hs
   other-modules:
       Paths_hid_examples
-  other-extensions: GADTs
+  autogen-modules:
+      Paths_hid_examples
+  other-extensions:
+      GADTs
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable elevator
@@ -496,11 +577,12 @@ executable elevator
       ch13/elevator/
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-unticked-promoted-constructors
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , dec >=0.0.3 && <0.1
     , fin >=0.1 && <0.3
     , mtl >=2.0 && <2.3
-    , singletons >=2.5 && <2.8
+    , singletons >=2.5 && <3.1
+    , singletons-th ==3.1.*
   default-language: Haskell2010
 
 executable evalrpn1
@@ -511,7 +593,7 @@ executable evalrpn1
       expr/rpn
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , mtl >=2.0 && <2.3
   default-language: Haskell2010
 
@@ -523,7 +605,7 @@ executable evalrpn2
       expr/rpn
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , mtl >=2.0 && <2.3
   default-language: Haskell2010
 
@@ -534,33 +616,44 @@ executable evalrpn3
       EvalRPNTrans2
   hs-source-dirs:
       expr/rpn
-  other-extensions: FlexibleInstances MultiParamTypeClasses UndecidableInstances InstanceSigs LambdaCase
+  other-extensions:
+      FlexibleInstances
+      MultiParamTypeClasses
+      UndecidableInstances
+      InstanceSigs
+      LambdaCase
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , mtl >=2.0 && <2.3
-    , transformers >=0.5 && <0.6
+    , transformers ==0.5.*
   default-language: Haskell2010
 
 executable expr-gadt
   main-is: expr/gadts/Main.hs
   other-modules:
       Paths_hid_examples
-  other-extensions: GADTSyntax GADTs
+  autogen-modules:
+      Paths_hid_examples
+  other-extensions:
+      GADTSyntax
+      GADTs
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-type-defaults -Wno-missing-signatures
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable filecount
   main-is: filecount.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch05
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , extra >=1.5 && <1.8
   default-language: Haskell2010
 
@@ -568,11 +661,13 @@ executable gcd
   main-is: gcd.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch05
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , mtl >=2.0 && <2.3
   default-language: Haskell2010
 
@@ -580,14 +675,18 @@ executable genSQL
   main-is: genSQL.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch05
-  other-extensions: OverloadedStrings ViewPatterns
+  other-extensions:
+      OverloadedStrings
+      ViewPatterns
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , mtl >=2.0 && <2.3
-    , text >=1.2 && <1.3
+    , text ==1.2.*
   default-language: Haskell2010
 
 executable generic-sql
@@ -595,21 +694,26 @@ executable generic-sql
   other-modules:
       GenericSQL
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch12/genSQL/
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
-    , text >=1.2 && <1.3
+      base ==4.16.*
+    , text ==1.2.*
     , text-show >=3.0 && <4
   default-language: Haskell2010
 
 executable hasql
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
+  default-language: Haskell2010
   if flag(with-pg)
     main-is: Main.hs
     other-modules:
@@ -622,22 +726,24 @@ executable hasql
         ch15
     build-depends:
         hasql >=1.3 && <1.5
-      , hasql-th >=0.4 && <0.5
+      , hasql-th ==0.4.*
       , mtl >=2.0 && <2.3
       , profunctors >=5.3 && <5.7
-      , text >=1.2 && <1.3
+      , text ==1.2.*
       , text-show >=3.0 && <4
       , vector >=0.11 && <0.13
   else
     main-is: empty/Main.hs
-  default-language: Haskell2010
 
 executable hdbc
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
+  default-language: Haskell2010
   if flag(with-pg)
     main-is: hdbc.hs
     other-modules:
@@ -648,17 +754,16 @@ executable hdbc
         HDBC >=2.3 && <2.5
       , HDBC-postgresql >=2.3 && <2.5
       , convertible >=1.0 && <1.2
-      , text >=1.2 && <1.3
+      , text ==1.2.*
       , text-show >=3.0 && <4
   else
     main-is: empty/Main.hs
-  default-language: Haskell2010
 
 executable hello
   main-is: intro/hello.hs
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable hello-th
@@ -669,62 +774,72 @@ executable hello-th
       ch12/th/hello/
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
-    , template-haskell >=2.13 && <2.17
+      base ==4.16.*
+    , template-haskell >=2.13 && <2.19
   default-language: Haskell2010
 
 executable interleaving
   main-is: ch16/interleaving.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -threaded
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable ioref
   main-is: ioref.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch05
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable ipgen
   main-is: ip/gen/Main.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
-    , exceptions >=0.10 && <0.11
-    , hedgehog >=0.5 && <1.1
+      base ==4.16.*
+    , exceptions ==0.10.*
+    , hedgehog >=0.5 && <1.2
     , ipgen-lib
-    , optparse-applicative >=0.14 && <0.17
+    , optparse-applicative ==0.17.*
   default-language: Haskell2010
 
 executable iplookup
   main-is: ip/lookup/Main.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
-    , exceptions >=0.10 && <0.11
+      base ==4.16.*
+    , exceptions ==0.10.*
     , iplookup-lib
-    , optparse-applicative >=0.14 && <0.17
+    , optparse-applicative ==0.17.*
   default-language: Haskell2010
 
 executable iplookup-simulation
   main-is: ip/iplookup-simulation.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , iplookup-lib
   default-language: Haskell2010
 
@@ -736,45 +851,51 @@ executable isprime
       ch09/isprime
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , isprime-lib
-    , timeit >=2.0 && <2.1
+    , timeit ==2.0.*
   default-language: Haskell2010
 
 executable lens-ex
   main-is: ch14/lens-ex.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
-    , lens >=4.17 && <4.20
+      base ==4.16.*
+    , lens ==5.1.*
   default-language: Haskell2010
 
 executable logging
   main-is: logging.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch07
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
-    , monad-logger >=0.3 && <0.4
+      base ==4.16.*
+    , monad-logger ==0.3.*
     , mtl >=2.0 && <2.3
-    , text >=1.2 && <1.3
-    , transformers >=0.5 && <0.6
+    , text ==1.2.*
+    , transformers ==0.5.*
   default-language: Haskell2010
 
 executable maybe
   main-is: maybe.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch05
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable mstr-literals
@@ -785,29 +906,33 @@ executable mstr-literals
       ch12/th/mstr-lits/
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-missing-signatures -Wno-incomplete-patterns
   build-depends:
-      base >=4.12 && <4.15
-    , template-haskell >=2.13 && <2.17
+      base ==4.16.*
+    , template-haskell >=2.13 && <2.19
   default-language: Haskell2010
 
 executable mvar-deadlocks
   main-is: ch16/mvar-deadlocks.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -threaded -Wno-unused-do-bind
   build-depends:
       async >=2.0 && <2.3
-    , base >=4.12 && <4.15
+    , base ==4.16.*
   default-language: Haskell2010
 
 executable newtype
   main-is: newtype.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch12/deriv/
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , mtl >=2.0 && <2.3
   default-language: Haskell2010
 
@@ -816,20 +941,26 @@ executable nummod-rank-n
   other-modules:
       NumUtils
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch11/nummod-rank-n/
-  other-extensions: RankNTypes
+  other-extensions:
+      RankNTypes
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable opaleye
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
+  default-language: Haskell2010
   if flag(with-pg)
     main-is: Main.hs
     other-modules:
@@ -843,24 +974,25 @@ executable opaleye
         ch15
     build-depends:
         bytestring >=0.10 && <0.12
-      , opaleye >=0.7 && <0.8
+      , opaleye ==0.7.*
       , postgresql-simple >=0.5 && <0.7
-      , product-profunctors >=0.11 && <0.12
+      , product-profunctors ==0.11.*
       , profunctors >=5.3 && <5.7
-      , text >=1.2 && <1.3
+      , text ==1.2.*
       , text-show >=3.0 && <4
   else
     main-is: empty/Main.hs
-  default-language: Haskell2010
 
 executable ordered-threads
   main-is: ch16/ordered-threads.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -threaded
   build-depends:
       async >=2.0 && <2.3
-    , base >=4.12 && <4.15
+    , base ==4.16.*
     , stm >=2.4 && <2.6
   default-language: Haskell2010
 
@@ -872,7 +1004,7 @@ executable person-derived
       ch02/person
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable person-implemented
@@ -883,7 +1015,7 @@ executable person-implemented
       ch02/person
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable person-text
@@ -894,16 +1026,19 @@ executable person-text
       ch02/person
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , text-show >=3.0 && <4
   default-language: Haskell2010
 
 executable pg-simple
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
+  default-language: Haskell2010
   if flag(with-pg)
     main-is: pg-simple.hs
     other-modules:
@@ -914,11 +1049,10 @@ executable pg-simple
     build-depends:
         bytestring >=0.10 && <0.12
       , postgresql-simple >=0.5 && <0.7
-      , text >=1.2 && <1.3
+      , text ==1.2.*
       , text-show >=3.0 && <4
   else
     main-is: empty/Main.hs
-  default-language: Haskell2010
 
 executable ping-client
   main-is: client.hs
@@ -928,8 +1062,8 @@ executable ping-client
       ch12/rpc/ping/
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
-    , cereal >=0.5 && <0.6
+      base ==4.16.*
+    , cereal ==0.5.*
     , mtl >=2.0 && <2.3
     , rpc-lib
   default-language: Haskell2010
@@ -942,8 +1076,8 @@ executable ping-server
       ch12/rpc/ping/
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
-    , cereal >=0.5 && <0.6
+      base ==4.16.*
+    , cereal ==0.5.*
     , mtl >=2.0 && <2.3
     , rpc-lib
   default-language: Haskell2010
@@ -956,8 +1090,8 @@ executable predicates
       ch12/th/predicates/
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-missing-signatures -Wno-incomplete-patterns
   build-depends:
-      base >=4.12 && <4.15
-    , template-haskell >=2.13 && <2.17
+      base ==4.16.*
+    , template-haskell >=2.13 && <2.19
   default-language: Haskell2010
 
 executable prefix-postfix
@@ -969,7 +1103,7 @@ executable prefix-postfix
       expr
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , mtl >=2.0 && <2.3
     , text-show >=3.0 && <4
   default-language: Haskell2010
@@ -982,20 +1116,22 @@ executable projectors
       ch12/th/projectors/
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
-    , template-haskell >=2.13 && <2.17
+      base ==4.16.*
+    , template-haskell >=2.13 && <2.19
   default-language: Haskell2010
 
 executable pub-sub
   main-is: ch16/pub-sub.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -threaded
   build-depends:
       async >=2.0 && <2.3
-    , base >=4.12 && <4.15
+    , base ==4.16.*
     , stm >=2.4 && <2.6
-    , stm-chans >=3.0 && <3.1
+    , stm-chans ==3.0.*
   default-language: Haskell2010
 
 executable radar
@@ -1004,10 +1140,11 @@ executable radar
       Radar
   hs-source-dirs:
       ch02/radar
-  other-extensions: DeriveAnyClass
+  other-extensions:
+      DeriveAnyClass
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , fmt >=0.5 && <0.7
   default-language: Haskell2010
 
@@ -1015,12 +1152,15 @@ executable reader
   main-is: reader.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch05
-  other-extensions: NamedFieldPuns
+  other-extensions:
+      NamedFieldPuns
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , mtl >=2.0 && <2.3
   default-language: Haskell2010
 
@@ -1030,23 +1170,26 @@ executable rpnexpr
       EvalRPNExcept
   hs-source-dirs:
       expr/rpn
-  other-extensions: OverloadedStrings
+  other-extensions:
+      OverloadedStrings
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , mtl >=2.0 && <2.3
-    , text >=1.2 && <1.3
+    , text ==1.2.*
     , text-show >=3.0 && <4
-    , transformers >=0.5 && <0.6
+    , transformers ==0.5.*
   default-language: Haskell2010
 
 executable simple-streaming
   main-is: ch14/simple-streaming.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable stockquotes
@@ -1058,22 +1201,28 @@ executable stockquotes
       QuoteData
       StatReport
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       stockquotes
-  other-extensions: RecordWildCards OverloadedStrings DeriveGeneric DeriveAnyClass
+  other-extensions:
+      RecordWildCards
+      OverloadedStrings
+      DeriveGeneric
+      DeriveAnyClass
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
       Chart >=1.8 && <1.10
     , Chart-diagrams >=1.8 && <1.10
-    , base >=4.12 && <4.15
+    , base ==4.16.*
     , blaze-colonnade >=1.1 && <1.3
-    , blaze-html >=0.9 && <0.10
+    , blaze-html ==0.9.*
     , bytestring >=0.10 && <0.12
-    , cassava >=0.5 && <0.6
+    , cassava ==0.5.*
     , colonnade >=1.1 && <1.3
     , fmt >=0.5 && <0.7
-    , optparse-applicative >=0.14 && <0.17
-    , text >=1.2 && <1.3
+    , optparse-applicative ==0.17.*
+    , text ==1.2.*
     , time >=1.8 && <1.12
   default-language: Haskell2010
 
@@ -1081,65 +1230,77 @@ executable strategies
   main-is: strategies.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch12/deriv/
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      aeson >=1.2 && <1.6
-    , base >=4.12 && <4.15
+      aeson ==2.0.*
+    , base ==4.16.*
   default-language: Haskell2010
 
 executable stream
   main-is: ch14/stream.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable stref
   main-is: stref.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch05
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable sum-numbers
   main-is: ch16/sum-numbers.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -threaded
   build-depends:
       async >=2.0 && <2.3
-    , base >=4.12 && <4.15
+    , base ==4.16.*
   default-language: Haskell2010
 
 executable sum-numbers-many-workers
   main-is: ch16/sum-numbers-many-workers.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -threaded
   build-depends:
       async >=2.0 && <2.3
-    , base >=4.12 && <4.15
+    , base ==4.16.*
     , stm >=2.4 && <2.6
-    , stm-chans >=3.0 && <3.1
+    , stm-chans ==3.0.*
   default-language: Haskell2010
 
 executable sumlist
   main-is: sumlist.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch05
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , mtl >=2.0 && <2.3
   default-language: Haskell2010
 
@@ -1147,12 +1308,14 @@ executable sumtab
   main-is: ch14/sumtab.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , extra >=1.5 && <1.8
     , streaming >=0.2.2 && <0.4
-    , text >=1.2 && <1.3
+    , text ==1.2.*
     , text-show >=3.0 && <4
   default-language: Haskell2010
 
@@ -1166,33 +1329,43 @@ executable suntimes
       SunTimes
       Types
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       suntimes
-  default-extensions: OverloadedStrings
-  other-extensions: RecordWildCards DeriveGeneric
+  default-extensions:
+      OverloadedStrings
+  other-extensions:
+      RecordWildCards
+      DeriveGeneric
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      aeson >=1.2 && <1.6
-    , base >=4.12 && <4.15
+      aeson ==2.0.*
+    , base ==4.16.*
     , bytestring >=0.10 && <0.12
-    , exceptions >=0.10 && <0.11
+    , exceptions ==0.10.*
     , http-client >=0.4 && <0.8
     , mtl >=2.0 && <2.3
-    , optparse-applicative >=0.14 && <0.17
-    , req >=2.0 && <3.10
-    , text >=1.2 && <1.3
+    , optparse-applicative ==0.17.*
+    , req >=2.0 && <3.14
+    , text ==1.2.*
     , time >=1.8 && <1.12
-    , transformers >=0.5 && <0.6
+    , transformers ==0.5.*
   default-language: Haskell2010
 
 executable temp-kinds
   main-is: temp-kinds.hs
   hs-source-dirs:
       ch11/temperature
-  other-extensions: GeneralizedNewtypeDeriving ScopedTypeVariables PolyKinds AllowAmbiguousTypes TypeApplications
+  other-extensions:
+      GeneralizedNewtypeDeriving
+      ScopedTypeVariables
+      PolyKinds
+      AllowAmbiguousTypes
+      TypeApplications
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-unticked-promoted-constructors
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable temp-proxies
@@ -1202,10 +1375,14 @@ executable temp-proxies
       UnitNameProxies
   hs-source-dirs:
       ch11/temperature
-  other-extensions: GeneralizedNewtypeDeriving ScopedTypeVariables PolyKinds InstanceSigs
+  other-extensions:
+      GeneralizedNewtypeDeriving
+      ScopedTypeVariables
+      PolyKinds
+      InstanceSigs
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable temp-type-apps
@@ -1215,20 +1392,27 @@ executable temp-type-apps
       UnitNameTypeApps
   hs-source-dirs:
       ch11/temperature
-  other-extensions: GeneralizedNewtypeDeriving ScopedTypeVariables PolyKinds AllowAmbiguousTypes TypeApplications
+  other-extensions:
+      GeneralizedNewtypeDeriving
+      ScopedTypeVariables
+      PolyKinds
+      AllowAmbiguousTypes
+      TypeApplications
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable tree-async
   main-is: ch16/tree-async.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -threaded
   build-depends:
       async >=2.0 && <2.3
-    , base >=4.12 && <4.15
+    , base ==4.16.*
   default-language: Haskell2010
 
 executable type-families
@@ -1239,12 +1423,16 @@ executable type-families
       Unescape
       XListable
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch11/type-families
-  other-extensions: TypeFamilies FlexibleInstances
+  other-extensions:
+      TypeFamilies
+      FlexibleInstances
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-type-defaults
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , containers >=0.5 && <0.7
   default-language: Haskell2010
 
@@ -1255,28 +1443,37 @@ executable type-lits
       SuffixedStrings
   hs-source-dirs:
       ch11/type-lits
-  other-extensions: DataKinds KindSignatures ScopedTypeVariables
+  other-extensions:
+      DataKinds
+      KindSignatures
+      ScopedTypeVariables
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable type-operators
   main-is: ch11/type-operators.hs
-  other-extensions: TypeOperators NoStarIsType
+  other-extensions:
+      TypeOperators
+      NoStarIsType
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable unboxed
   main-is: ch09/unboxed.hs
   other-modules:
       Paths_hid_examples
-  other-extensions: UnboxedTuples UnboxedSums
+  autogen-modules:
+      Paths_hid_examples
+  other-extensions:
+      UnboxedTuples
+      UnboxedSums
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable unsafe-elevator
@@ -1288,7 +1485,7 @@ executable unsafe-elevator
       ch13/elevator/
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , mtl >=2.0 && <2.3
   default-language: Haskell2010
 
@@ -1296,22 +1493,26 @@ executable via
   main-is: via.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch12/deriv/
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable view-generic
   main-is: view-generic.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch12/generics/
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-missing-signatures
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
   default-language: Haskell2010
 
 executable vocab1
@@ -1320,8 +1521,8 @@ executable vocab1
       ch01
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
-    , text >=1.2 && <1.3
+      base ==4.16.*
+    , text ==1.2.*
   default-language: Haskell2010
 
 executable vocab2
@@ -1330,43 +1531,48 @@ executable vocab2
       ch01
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
-    , text >=1.2 && <1.3
+      base ==4.16.*
+    , text ==1.2.*
   default-language: Haskell2010
 
 executable vocab3
   main-is: vocab3.hs
   hs-source-dirs:
       ch01
-  other-extensions: OverloadedStrings
+  other-extensions:
+      OverloadedStrings
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , fmt >=0.5 && <0.7
-    , text >=1.2 && <1.3
+    , text ==1.2.*
   default-language: Haskell2010
 
 executable wait-completion
   main-is: ch16/wait-completion.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -threaded
   build-depends:
-      base >=4.12 && <4.15
-    , random >=1.2 && <1.3
+      base ==4.16.*
+    , random ==1.2.*
   default-language: Haskell2010
 
 executable weapons
   main-is: weapons.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       ch05
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , mtl >=2.0 && <2.3
-    , random >=1.2 && <1.3
+    , random ==1.2.*
   default-language: Haskell2010
 
 test-suite expr-simple-test
@@ -1376,7 +1582,7 @@ test-suite expr-simple-test
       tests/expr
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , expr-simple
     , hint >=0.7 && <0.10
     , text-show >=3.0 && <4
@@ -1387,11 +1593,13 @@ test-suite iplookup-doctest
   main-is: tests/iplookup-doctest/Doctests.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , doctest >=0.12 && <0.19
-    , split >=0.2 && <0.3
+    , split ==0.2.*
   default-language: Haskell2010
 
 test-suite iplookup-test
@@ -1403,19 +1611,21 @@ test-suite iplookup-test
       ParseIPSpec
       Props
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       tests/iplookup
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-type-defaults
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , filepath >=1.4.1 && <1.5
-    , hedgehog >=0.5 && <1.1
+    , hedgehog >=0.5 && <1.2
     , ipgen-lib
     , iplookup-lib
     , tasty >=0.11 && <1.5
-    , tasty-golden >=2.3 && <2.4
-    , tasty-hedgehog >=0.1 && <1.1
-    , tasty-hspec >=1.1 && <1.2
+    , tasty-golden ==2.3.*
+    , tasty-hedgehog >=0.1 && <1.2
+    , tasty-hspec ==1.1.*
   default-language: Haskell2010
 
 test-suite radar-test
@@ -1425,9 +1635,9 @@ test-suite radar-test
       tests/radar
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , radar-lib
-    , random >=1.2 && <1.3
+    , random ==1.2.*
   default-language: Haskell2010
 
 test-suite shunting-yard-test
@@ -1437,9 +1647,9 @@ test-suite shunting-yard-test
       tests/expr
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , shunting-yard
-    , text >=1.2 && <1.3
+    , text ==1.2.*
     , text-show >=3.0 && <4
   default-language: Haskell2010
 
@@ -1455,11 +1665,13 @@ benchmark iplookup-bench
       Data
       NFUtils
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   hs-source-dirs:
       benchmarks/iplookup
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , criterion >=1.4 && <1.6
     , deepseq >=1.3 && <1.5
     , iplookup-lib
@@ -1470,9 +1682,11 @@ benchmark primcheck
   main-is: benchmarks/primcheck.hs
   other-modules:
       Paths_hid_examples
+  autogen-modules:
+      Paths_hid_examples
   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
   build-depends:
-      base >=4.12 && <4.15
+      base ==4.16.*
     , criterion >=1.4 && <1.6
     , isprime-lib
   default-language: Haskell2010

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -582,6 +582,7 @@ executable elevator
     , fin >=0.1 && <0.3
     , mtl >=2.0 && <2.3
     , singletons >=2.5 && <3.1
+    , singletons-base
     , singletons-th ==3.1.*
   default-language: Haskell2010
 

--- a/package.yaml
+++ b/package.yaml
@@ -27,9 +27,9 @@ data-files:
     - data/tests/iplookup/*.*
     - data/benchmarks/iplookup/*.*
 
-tested-with: GHC == 8.6.5, GHC == 8.8.3
+tested-with: GHC == 9.2.7
 
-dependencies: base >=4.12 && <4.15
+dependencies: base >=4.16 && <4.17
 
 flags:
   with-pg:
@@ -108,7 +108,7 @@ executables:
         dependencies:
           - bytestring >=0.10 && <0.12
           - blaze-html >=0.9 && <0.10
-          - optparse-applicative >=0.14 && <0.17
+          - optparse-applicative >=0.17 && <0.18
           - time >=1.8 && <1.12
           - text >=1.2 && <1.3
           - fmt >=0.5 && <0.7
@@ -214,7 +214,7 @@ executables:
           - filepath >= 1.4.1 && < 1.5
           - directory >= 1.3 && < 1.4
           - unix-compat >= 0.5 && < 0.6
-          - optparse-applicative >= 0.14 && < 0.17
+          - optparse-applicative >= 0.17 && < 0.18
           - text >=1.2 && <1.3
           - text-show >=3.0 && <4
           - extra >=1.5 && <1.8
@@ -251,10 +251,10 @@ executables:
           - time >=1.8 && <1.12
           - text >=1.2 && <1.3
           - exceptions >= 0.10 && < 0.11
-          - aeson >= 1.2 && < 1.6
-          - req >= 2.0 && < 3.10
+          - aeson >= 2.0 && < 2.1
+          - req >= 2.0 && < 3.14
           - http-client >= 0.4 && < 0.8
-          - optparse-applicative >= 0.14 && < 0.17
+          - optparse-applicative >= 0.17 && < 0.18
           - bytestring >= 0.10 && < 0.12
         default-extensions:
           - OverloadedStrings
@@ -274,15 +274,15 @@ executables:
         main: ip/lookup/Main.hs
         dependencies:
           - exceptions >= 0.10 && < 0.11
-          - optparse-applicative >= 0.14 && < 0.17
+          - optparse-applicative >= 0.17 && < 0.18
           - iplookup-lib
     ipgen:
         main: ip/gen/Main.hs
         dependencies:
           - ipgen-lib
           - exceptions >= 0.10 && < 0.11
-          - optparse-applicative >= 0.14 && < 0.17
-          - hedgehog >= 0.5 && < 1.1
+          - optparse-applicative >= 0.17 && < 0.18
+          - hedgehog >= 0.5 && < 1.2
     # Chapter 9
     unboxed:
         main: ch09/unboxed.hs
@@ -382,7 +382,7 @@ executables:
         source-dirs: ch12/deriv/
         main: strategies.hs
         dependencies:
-          - aeson >= 1.2 && < 1.6
+          - aeson >= 2.0 && < 2.1
     coerce:
         source-dirs: ch12/deriv/
         main: coerce.hs
@@ -412,19 +412,19 @@ executables:
         main: Main.hs
         other-modules: [ Hello ]
         dependencies:
-          - template-haskell >=2.13 && <2.17
+          - template-haskell >=2.13 && <2.19
     projectors:
         source-dirs: ch12/th/projectors/
         main: Main.hs
         other-modules: [ Projectors ]
         dependencies:
-          - template-haskell >=2.13 && <2.17
+          - template-haskell >=2.13 && <2.19
     predicates:
         source-dirs: ch12/th/predicates/
         main: Main.hs
         other-modules: [ Predicates ]
         dependencies:
-          - template-haskell >=2.13 && <2.17
+          - template-haskell >=2.13 && <2.19
         ghc-options:
           - -Wno-missing-signatures
           - -Wno-incomplete-patterns
@@ -433,7 +433,7 @@ executables:
         main: Main.hs
         other-modules: [ Str ]
         dependencies:
-          - template-haskell >=2.13 && <2.17
+          - template-haskell >=2.13 && <2.19
         ghc-options:
           - -Wno-missing-signatures
           - -Wno-incomplete-patterns
@@ -480,10 +480,10 @@ executables:
     api-servant:
         main: ch13/api/ApiServant.hs
         dependencies:
-          - servant-server >=0.14 && <0.19
+          - servant-server >=0.14 && <0.20
           - servant-blaze >=0.7 && <0.10
           - warp >=3.2 && < 3.4
-          - aeson >= 1.2 && < 1.6
+          - aeson >= 2.0 && < 2.1
           - blaze-html >=0.9 && <0.10
     unsafe-elevator:
         source-dirs: ch13/elevator/
@@ -510,7 +510,8 @@ executables:
           - KindSignatures
           - StandaloneDeriving
         dependencies:
-          - singletons >= 2.5 && < 2.8
+          - singletons >= 2.5 && < 3.1
+          - singletons-th >=3.1 && < 3.2
         ghc-options:
           - -Wno-unticked-promoted-constructors
     elevator:
@@ -525,7 +526,8 @@ executables:
         dependencies:
           - fin >= 0.1 && < 0.3
           - dec >= 0.0.3 && < 0.1
-          - singletons >= 2.5 && < 2.8
+          - singletons >= 2.5 && < 3.1
+          - singletons-th >= 3.1 && < 3.2
           - mtl >=2.0 && <2.3
         ghc-options:
           - -Wno-unticked-promoted-constructors
@@ -556,7 +558,7 @@ executables:
         main: ch14/csv-simple.hs
         dependencies:
           - text >=1.2 && <1.3
-          - attoparsec >=0.13 && <0.14
+          - attoparsec >=0.14 && <0.15
           - bytestring >=0.10 && <0.12
           - streaming-utils >=0.2 && <0.3
           - streaming-bytestring >=0.1.7 && <0.3
@@ -565,7 +567,7 @@ executables:
     lens-ex:
         main: ch14/lens-ex.hs
         dependencies:
-          - lens >= 4.17 && < 4.20
+          - lens >= 5.1 && < 5.2
     covid:
         source-dirs: ch14/covid
         main: Main.hs
@@ -575,12 +577,12 @@ executables:
           - text >=1.2 && <1.3
           - text-show >=3.0 && <4
           - containers >= 0.5 && < 0.7
-          - lens >= 4.17 && < 4.20
+          - lens >= 5.1 && < 5.2
           - streaming-utils >=0.2 && <0.3
           - streaming-bytestring >=0.1.7 && <0.3
           - streaming >=0.2.2 && <0.4
           - resourcet >=1.2 && <1.3
-          - attoparsec >=0.13 && <0.14
+          - attoparsec >=0.14 && <0.15
     # Chapter 15
     hdbc:
         when:
@@ -786,7 +788,7 @@ internal-libraries:
         other-modules: []
         dependencies:
           - iplookup-lib
-          - hedgehog >= 0.5 && < 1.1
+          - hedgehog >= 0.5 && < 1.2
     # Chapter 9
     isprime-lib:
       source-dirs: ch09/isprime
@@ -809,7 +811,7 @@ internal-libraries:
         - connection >= 0.3 && <0.4
         - network-simple >=0.4.5 && <0.5
         - exceptions >= 0.10 && < 0.11
-        - template-haskell >= 2.13 && <2.17
+        - template-haskell >= 2.13 && <2.19
         - haskell-src-exts >= 1.20 && <1.24
         - haskell-src-meta >= 0.6 && < 0.9
 tests:
@@ -847,8 +849,8 @@ tests:
           - ipgen-lib
           - tasty >= 0.11 && < 1.5
           - tasty-hspec >= 1.1 && < 1.2
-          - tasty-hedgehog >= 0.1 && < 1.1
-          - hedgehog >= 0.5 && < 1.1
+          - tasty-hedgehog >= 0.1 && < 1.2
+          - hedgehog >= 0.5 && < 1.2
           - tasty-golden >= 2.3 && < 2.4
           - filepath >= 1.4.1 && < 1.5
         ghc-options:

--- a/package.yaml
+++ b/package.yaml
@@ -528,6 +528,7 @@ executables:
           - dec >= 0.0.3 && < 0.1
           - singletons >= 2.5 && < 3.1
           - singletons-th >= 3.1 && < 3.2
+          - singletons-base
           - mtl >=2.0 && <2.3
         ghc-options:
           - -Wno-unticked-promoted-constructors

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,33 +1,14 @@
-resolver: lts-18.21
+resolver: lts-20.21
 
 packages:
 - .
 
-allow-newer: true
 
 flags:
 #  hid-examples:
 #    with-pg: True
 
 extra-deps:
-  - Chart-diagrams-1.9.3
-  - HDBC-postgresql-2.4.0.0
-  - SVGFonts-1.7.0.1
-  - active-0.2.0.15
   - blaze-colonnade-1.2.2.1
   - colonnade-1.2.0.2
-  - diagrams-core-1.5.0
-  - diagrams-lib-1.4.5.1
-  - diagrams-postscript-1.5
-  - diagrams-svg-1.4.3.1
-  - dual-tree-0.2.3.0
-  - fast-builder-0.1.3.0
-  - hasql-th-0.4.0.10
-  - headed-megaparsec-0.2.0.2
-  - json-stream-0.4.2.4
-  - monoid-extras-0.6.1
-  - postgresql-syntax-0.4
-  - statestack-0.3
-  - streaming-utils-0.2.1.0
-  - svg-builder-0.1.1
-  - template-haskell-compat-v0208-0.1.5
+  - streaming-utils-0.2.4.0


### PR DESCRIPTION
This makes `stack build hid-examples:elevator` proceed further.

I added this because somebody noted that `Data.Eq.Singletons` was the missing module: https://github.com/goldfirere/singletons/issues/536#issuecomment-1229174146
And that module is from singletons-base.

I am not sure it is a good idea to remove the extensions list, since singletons explicitly lists them as being required:
https://github.com/goldfirere/singletons#compatibility
